### PR TITLE
Rewind fix

### DIFF
--- a/common/format.go
+++ b/common/format.go
@@ -80,3 +80,10 @@ func (t PrettyAge) String() string {
 	}
 	return result
 }
+
+type PrettySeconds int
+
+// Returns int to formatted seconds
+func (t PrettySeconds) String() string {
+	return fmt.Sprintf("%ds", t)
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -137,8 +137,8 @@ type CacheConfig struct {
 	SnapshotLimit       int           // Memory allowance (MB) to use for caching snapshot entries in memory
 	Preimages           bool          // Whether to store preimage of trie key to the disk
 
-	AllowForceUpdate bool // Enable to force snapshots based on commit counts
-	CommitThreshold  int  // Number of commits to force a root snapshot
+	AllowForceUpdate bool // Enable to force root snapshots based on the configured commits threshold
+	CommitThreshold  int  // Threshold of commits to force a root snapshot update
 	SnapshotNoBuild  bool // Whether the background generation is allowed
 	SnapshotWait     bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 }
@@ -1374,7 +1374,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 
 	current := block.NumberU64()
 	// Flush limits are not considered for the first TriesInMemory blocks.
-	log.Debug("Trie in memory", "current", current, "inMemory", TriesInMemory)
+	log.Trace("Trie in memory", "current", current, "inMemory", TriesInMemory)
 	if current <= TriesInMemory {
 		return nil
 	}
@@ -1390,7 +1390,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	// Find the next state trie we need to commit
 	chosen := current - TriesInMemory
 	flushInterval := time.Duration(bc.flushInterval.Load())
-	log.Debug("Flush Interval", "proc", bc.gcproc, "interval", flushInterval, "block", chosen, "flushing", (bc.gcproc > flushInterval))
+	log.Trace("Flush Interval", "proc", bc.gcproc, "interval", flushInterval, "block", chosen, "flushing", (bc.gcproc > flushInterval))
 	// If we exceeded time allowance, flush an entire trie to disk
 	if bc.gcproc > flushInterval {
 		// If the header is missing (canonical chain behind), we're reorging a low

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -624,7 +624,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 	// current freezer limit to start nuking id underflown
 	pivot := rawdb.ReadLastPivotNumber(bc.db)
 	frozen, _ := bc.db.Ancients()
-	log.Debug("Pivot and frozen block", "pivot", *pivot, "frozen", frozen)
+	log.Debug("Pivot and frozen block", "frozen", frozen)
 	updateFn := func(db ethdb.KeyValueWriter, header *types.Header) (*types.Header, bool) {
 		// Rewind the blockchain, ensuring we don't end up with a stateless head
 		// block. Note, depth equality is permitted to allow using SetHead as a

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -397,10 +397,11 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 			recover = true
 		}
 		snapconfig := snapshot.Config{
-			CacheSize:  bc.cacheConfig.SnapshotLimit,
-			Recovery:   recover,
-			NoBuild:    bc.cacheConfig.SnapshotNoBuild,
-			AsyncBuild: !bc.cacheConfig.SnapshotWait,
+			CacheSize:              bc.cacheConfig.SnapshotLimit,
+			Recovery:               recover,
+			NoBuild:                bc.cacheConfig.SnapshotNoBuild,
+			AsyncBuild:             !bc.cacheConfig.SnapshotWait,
+			EnableSnapRootInterval: true,
 		}
 		bc.snaps, _ = snapshot.New(snapconfig, bc.db, bc.triedb, head.Root)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -611,6 +611,7 @@ func (bc *BlockChain) SetSafe(header *types.Header) {
 //
 // The method returns the block number where the requested root cap was found.
 func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Hash, repair bool) (uint64, error) {
+	log.Debug("Setting Head beyond root", "root", root)
 	if !bc.chainmu.TryLock() {
 		return 0, errChainStopped
 	}
@@ -623,7 +624,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 	// current freezer limit to start nuking id underflown
 	pivot := rawdb.ReadLastPivotNumber(bc.db)
 	frozen, _ := bc.db.Ancients()
-
+	log.Debug("Pivot and frozen block", "pivot", *pivot, "frozen", frozen)
 	updateFn := func(db ethdb.KeyValueWriter, header *types.Header) (*types.Header, bool) {
 		// Rewind the blockchain, ensuring we don't end up with a stateless head
 		// block. Note, depth equality is permitted to allow using SetHead as a
@@ -641,6 +642,8 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 
 				for {
 					// If a root threshold was requested but not yet crossed, check
+					// when we found the root, beyond root become true
+					log.Debug("Checking Root conditions", "beyondroot", !beyondRoot, "target", root, "current", newHeadBlock.Root())
 					if root != (common.Hash{}) && !beyondRoot && newHeadBlock.Root() == root {
 						beyondRoot, rootNumber = true, newHeadBlock.NumberU64()
 					}
@@ -1396,6 +1399,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 				log.Info("State in memory for too long, committing", "time", bc.gcproc, "allowance", flushInterval, "optimum", float64(chosen-bc.lastWrite)/TriesInMemory)
 			}
 			// Flush an entire trie and restart the counters
+			log.Info("Flushing trie", "number", chosen, "root", header.Root)
 			bc.triedb.Commit(header.Root, true)
 			bc.lastWrite = chosen
 			bc.gcproc = 0

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -137,18 +137,22 @@ type CacheConfig struct {
 	SnapshotLimit       int           // Memory allowance (MB) to use for caching snapshot entries in memory
 	Preimages           bool          // Whether to store preimage of trie key to the disk
 
-	SnapshotNoBuild bool // Whether the background generation is allowed
-	SnapshotWait    bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
+	EnableSnapRootInterval bool // Enable to force snapshots based on time Interval
+	SnapRootThreshold      int  // Time in seconds to force a root snapshot
+	SnapshotNoBuild        bool // Whether the background generation is allowed
+	SnapshotWait           bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 }
 
 // defaultCacheConfig are the default caching values if none are specified by the
 // user (also used during testing).
 var defaultCacheConfig = &CacheConfig{
-	TrieCleanLimit: 256,
-	TrieDirtyLimit: 256,
-	TrieTimeLimit:  5 * time.Minute,
-	SnapshotLimit:  256,
-	SnapshotWait:   true,
+	TrieCleanLimit:         256,
+	TrieDirtyLimit:         256,
+	TrieTimeLimit:          5 * time.Minute,
+	SnapshotLimit:          256,
+	SnapshotWait:           true,
+	EnableSnapRootInterval: false,
+	SnapRootThreshold:      600, // 10 min
 }
 
 // BlockChain represents the canonical chain given a database with a genesis
@@ -401,7 +405,8 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 			Recovery:               recover,
 			NoBuild:                bc.cacheConfig.SnapshotNoBuild,
 			AsyncBuild:             !bc.cacheConfig.SnapshotWait,
-			EnableSnapRootInterval: true,
+			EnableSnapRootInterval: bc.cacheConfig.EnableSnapRootInterval,
+			SnapRootThreshold:      bc.cacheConfig.SnapRootThreshold,
 		}
 		bc.snaps, _ = snapshot.New(snapconfig, bc.db, bc.triedb, head.Root)
 	}
@@ -612,7 +617,6 @@ func (bc *BlockChain) SetSafe(header *types.Header) {
 //
 // The method returns the block number where the requested root cap was found.
 func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Hash, repair bool) (uint64, error) {
-	log.Debug("Setting Head beyond root", "root", root)
 	if !bc.chainmu.TryLock() {
 		return 0, errChainStopped
 	}
@@ -625,7 +629,6 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 	// current freezer limit to start nuking id underflown
 	pivot := rawdb.ReadLastPivotNumber(bc.db)
 	frozen, _ := bc.db.Ancients()
-	log.Debug("Pivot and frozen block", "frozen", frozen)
 	updateFn := func(db ethdb.KeyValueWriter, header *types.Header) (*types.Header, bool) {
 		// Rewind the blockchain, ensuring we don't end up with a stateless head
 		// block. Note, depth equality is permitted to allow using SetHead as a
@@ -643,8 +646,6 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 
 				for {
 					// If a root threshold was requested but not yet crossed, check
-					// when we found the root, beyond root become true
-					log.Debug("Checking Root conditions", "beyondroot", !beyondRoot, "target", root, "current", newHeadBlock.Root())
 					if root != (common.Hash{}) && !beyondRoot && newHeadBlock.Root() == root {
 						beyondRoot, rootNumber = true, newHeadBlock.NumberU64()
 					}
@@ -1337,7 +1338,6 @@ func (bc *BlockChain) writeKnownBlock(block *types.Block) error {
 // writeBlockWithState writes block, metadata and corresponding state data to the
 // database.
 func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, state *state.StateDB) error {
-	log.Debug("Writing block with State")
 	// Calculate the total difficulty of the block
 	ptd := bc.GetTd(block.ParentHash(), block.NumberU64()-1)
 	if ptd == nil {
@@ -1374,7 +1374,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 
 	current := block.NumberU64()
 	// Flush limits are not considered for the first TriesInMemory blocks.
-	log.Debug("Trie in memory", "current", current, "inmemory", TriesInMemory)
+	log.Debug("Trie in memory", "current", current, "inMemory", TriesInMemory)
 	if current <= TriesInMemory {
 		return nil
 	}
@@ -1383,14 +1383,14 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		nodes, imgs = bc.triedb.Size()
 		limit       = common.StorageSize(bc.cacheConfig.TrieDirtyLimit) * 1024 * 1024
 	)
-	log.Debug("Trie dirty size", "size", nodes, "limit", limit, "imgs", imgs)
+
 	if nodes > limit || imgs > 4*1024*1024 {
 		bc.triedb.Cap(limit - ethdb.IdealBatchSize)
 	}
 	// Find the next state trie we need to commit
 	chosen := current - TriesInMemory
 	flushInterval := time.Duration(bc.flushInterval.Load())
-	log.Debug("Flush Interval", "proc", bc.gcproc, "interval", flushInterval)
+	log.Debug("Flush Interval", "proc", bc.gcproc, "interval", flushInterval, "block", chosen, "flushing", (bc.gcproc > flushInterval))
 	// If we exceeded time allowance, flush an entire trie to disk
 	if bc.gcproc > flushInterval {
 		// If the header is missing (canonical chain behind), we're reorging a low
@@ -1405,13 +1405,12 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 				log.Info("State in memory for too long, committing", "time", bc.gcproc, "allowance", flushInterval, "optimum", float64(chosen-bc.lastWrite)/TriesInMemory)
 			}
 			// Flush an entire trie and restart the counters
-			log.Info("Flushing trie", "number", chosen, "root", header.Root)
 			bc.triedb.Commit(header.Root, true)
 			bc.lastWrite = chosen
 			bc.gcproc = 0
 		}
 	}
-	log.Debug("Flusing Interval not reached")
+
 	// Garbage collect anything below our required write retention
 	for !bc.triegc.Empty() {
 		root, number := bc.triegc.Pop()
@@ -1438,7 +1437,6 @@ func (bc *BlockChain) WriteBlockAndSetHead(block *types.Block, receipts []*types
 // writeBlockAndSetHead is the internal implementation of WriteBlockAndSetHead.
 // This function expects the chain mutex to be held.
 func (bc *BlockChain) writeBlockAndSetHead(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, err error) {
-	log.Debug("Writing Block and set head")
 	if err := bc.writeBlockWithState(block, receipts, state); err != nil {
 		return NonStatTy, err
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -137,22 +137,22 @@ type CacheConfig struct {
 	SnapshotLimit       int           // Memory allowance (MB) to use for caching snapshot entries in memory
 	Preimages           bool          // Whether to store preimage of trie key to the disk
 
-	AllowForceUpdate        bool // Enable to force snapshots based on commit counts
-	SnapRootCommitThreshold int  // Number of commits to force a root snapshot
-	SnapshotNoBuild         bool // Whether the background generation is allowed
-	SnapshotWait            bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
+	AllowForceUpdate bool // Enable to force snapshots based on commit counts
+	CommitThreshold  int  // Number of commits to force a root snapshot
+	SnapshotNoBuild  bool // Whether the background generation is allowed
+	SnapshotWait     bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 }
 
 // defaultCacheConfig are the default caching values if none are specified by the
 // user (also used during testing).
 var defaultCacheConfig = &CacheConfig{
-	TrieCleanLimit:          256,
-	TrieDirtyLimit:          256,
-	TrieTimeLimit:           5 * time.Minute,
-	SnapshotLimit:           256,
-	SnapshotWait:            true,
-	AllowForceUpdate:        false,
-	SnapRootCommitThreshold: 100,
+	TrieCleanLimit:   256,
+	TrieDirtyLimit:   256,
+	TrieTimeLimit:    5 * time.Minute,
+	SnapshotLimit:    256,
+	SnapshotWait:     true,
+	AllowForceUpdate: false,
+	CommitThreshold:  128,
 }
 
 // BlockChain represents the canonical chain given a database with a genesis
@@ -401,12 +401,12 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 			recover = true
 		}
 		snapconfig := snapshot.Config{
-			CacheSize:               bc.cacheConfig.SnapshotLimit,
-			Recovery:                recover,
-			NoBuild:                 bc.cacheConfig.SnapshotNoBuild,
-			AsyncBuild:              !bc.cacheConfig.SnapshotWait,
-			AllowForceUpdate:        bc.cacheConfig.AllowForceUpdate,
-			SnapRootCommitThreshold: bc.cacheConfig.SnapRootCommitThreshold,
+			CacheSize:        bc.cacheConfig.SnapshotLimit,
+			Recovery:         recover,
+			NoBuild:          bc.cacheConfig.SnapshotNoBuild,
+			AsyncBuild:       !bc.cacheConfig.SnapshotWait,
+			AllowForceUpdate: bc.cacheConfig.AllowForceUpdate,
+			CommitThreshold:  bc.cacheConfig.CommitThreshold,
 		}
 		bc.snaps, _ = snapshot.New(snapconfig, bc.db, bc.triedb, head.Root)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -137,22 +137,22 @@ type CacheConfig struct {
 	SnapshotLimit       int           // Memory allowance (MB) to use for caching snapshot entries in memory
 	Preimages           bool          // Whether to store preimage of trie key to the disk
 
-	EnableSnapRootInterval bool // Enable to force snapshots based on time Interval
-	SnapRootThreshold      int  // Time in seconds to force a root snapshot
-	SnapshotNoBuild        bool // Whether the background generation is allowed
-	SnapshotWait           bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
+	AllowForceUpdate        bool // Enable to force snapshots based on commit counts
+	SnapRootCommitThreshold int  // Number of commits to force a root snapshot
+	SnapshotNoBuild         bool // Whether the background generation is allowed
+	SnapshotWait            bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 }
 
 // defaultCacheConfig are the default caching values if none are specified by the
 // user (also used during testing).
 var defaultCacheConfig = &CacheConfig{
-	TrieCleanLimit:         256,
-	TrieDirtyLimit:         256,
-	TrieTimeLimit:          5 * time.Minute,
-	SnapshotLimit:          256,
-	SnapshotWait:           true,
-	EnableSnapRootInterval: false,
-	SnapRootThreshold:      600, // 10 min
+	TrieCleanLimit:          256,
+	TrieDirtyLimit:          256,
+	TrieTimeLimit:           5 * time.Minute,
+	SnapshotLimit:           256,
+	SnapshotWait:            true,
+	AllowForceUpdate:        false,
+	SnapRootCommitThreshold: 100,
 }
 
 // BlockChain represents the canonical chain given a database with a genesis
@@ -401,12 +401,12 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 			recover = true
 		}
 		snapconfig := snapshot.Config{
-			CacheSize:              bc.cacheConfig.SnapshotLimit,
-			Recovery:               recover,
-			NoBuild:                bc.cacheConfig.SnapshotNoBuild,
-			AsyncBuild:             !bc.cacheConfig.SnapshotWait,
-			EnableSnapRootInterval: bc.cacheConfig.EnableSnapRootInterval,
-			SnapRootThreshold:      bc.cacheConfig.SnapRootThreshold,
+			CacheSize:               bc.cacheConfig.SnapshotLimit,
+			Recovery:                recover,
+			NoBuild:                 bc.cacheConfig.SnapshotNoBuild,
+			AsyncBuild:              !bc.cacheConfig.SnapshotWait,
+			AllowForceUpdate:        bc.cacheConfig.AllowForceUpdate,
+			SnapRootCommitThreshold: bc.cacheConfig.SnapRootCommitThreshold,
 		}
 		bc.snaps, _ = snapshot.New(snapconfig, bc.db, bc.triedb, head.Root)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1336,6 +1336,7 @@ func (bc *BlockChain) writeKnownBlock(block *types.Block) error {
 // writeBlockWithState writes block, metadata and corresponding state data to the
 // database.
 func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, state *state.StateDB) error {
+	log.Debug("Writing block with State")
 	// Calculate the total difficulty of the block
 	ptd := bc.GetTd(block.ParentHash(), block.NumberU64()-1)
 	if ptd == nil {
@@ -1361,6 +1362,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	if err != nil {
 		return err
 	}
+	log.Debug("Committed State", "root", root)
 	// If we're running an archive node, always flush
 	if bc.cacheConfig.TrieDirtyDisabled {
 		return bc.triedb.Commit(root, false)
@@ -1371,6 +1373,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 
 	current := block.NumberU64()
 	// Flush limits are not considered for the first TriesInMemory blocks.
+	log.Debug("Trie in memory", "current", current, "inmemory", TriesInMemory)
 	if current <= TriesInMemory {
 		return nil
 	}
@@ -1379,12 +1382,14 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		nodes, imgs = bc.triedb.Size()
 		limit       = common.StorageSize(bc.cacheConfig.TrieDirtyLimit) * 1024 * 1024
 	)
+	log.Debug("Trie dirty size", "size", nodes, "limit", limit, "imgs", imgs)
 	if nodes > limit || imgs > 4*1024*1024 {
 		bc.triedb.Cap(limit - ethdb.IdealBatchSize)
 	}
 	// Find the next state trie we need to commit
 	chosen := current - TriesInMemory
 	flushInterval := time.Duration(bc.flushInterval.Load())
+	log.Debug("Flush Interval", "proc", bc.gcproc, "interval", flushInterval)
 	// If we exceeded time allowance, flush an entire trie to disk
 	if bc.gcproc > flushInterval {
 		// If the header is missing (canonical chain behind), we're reorging a low
@@ -1405,6 +1410,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 			bc.gcproc = 0
 		}
 	}
+	log.Debug("Flusing Interval not reached")
 	// Garbage collect anything below our required write retention
 	for !bc.triegc.Empty() {
 		root, number := bc.triegc.Pop()
@@ -1431,6 +1437,7 @@ func (bc *BlockChain) WriteBlockAndSetHead(block *types.Block, receipts []*types
 // writeBlockAndSetHead is the internal implementation of WriteBlockAndSetHead.
 // This function expects the chain mutex to be held.
 func (bc *BlockChain) writeBlockAndSetHead(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, err error) {
+	log.Debug("Writing Block and set head")
 	if err := bc.writeBlockWithState(block, receipts, state); err != nil {
 		return NonStatTy, err
 	}

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -1808,7 +1808,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	if tt.commitBlock > 0 {
 		chain.stateCache.TrieDB().Commit(canonblocks[tt.commitBlock-1].Root(), false)
 		if snapshots {
-			if err := chain.snaps.Cap(canonblocks[tt.commitBlock-1].Root(), 0); err != nil {
+			if err := chain.snaps.Cap(canonblocks[tt.commitBlock-1].Root(), 0, false); err != nil {
 				t.Fatalf("Failed to flatten snapshots: %v", err)
 			}
 		}
@@ -1935,7 +1935,7 @@ func TestIssue23496(t *testing.T) {
 	if _, err := chain.InsertChain(blocks[1:2]); err != nil {
 		t.Fatalf("Failed to import canonical chain start: %v", err)
 	}
-	if err := chain.snaps.Cap(blocks[1].Root(), 0); err != nil {
+	if err := chain.snaps.Cap(blocks[1].Root(), 0, false); err != nil {
 		t.Fatalf("Failed to flatten snapshots: %v", err)
 	}
 

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -2009,7 +2009,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 	if tt.commitBlock > 0 {
 		chain.stateCache.TrieDB().Commit(canonblocks[tt.commitBlock-1].Root(), false)
 		if snapshots {
-			if err := chain.snaps.Cap(canonblocks[tt.commitBlock-1].Root(), 0); err != nil {
+			if err := chain.snaps.Cap(canonblocks[tt.commitBlock-1].Root(), 0, false); err != nil {
 				t.Fatalf("Failed to flatten snapshots: %v", err)
 			}
 		}

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -108,7 +108,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 			// Flushing the entire snap tree into the disk, the
 			// relevant (a) snapshot root and (b) snapshot generator
 			// will be persisted atomically.
-			chain.snaps.Cap(blocks[point-1].Root(), 0)
+			chain.snaps.Cap(blocks[point-1].Root(), 0, false)
 			diskRoot, blockRoot := chain.snaps.DiskRoot(), blocks[point-1].Root()
 			if !bytes.Equal(diskRoot.Bytes(), blockRoot.Bytes()) {
 				t.Fatalf("Failed to flush disk layer change, want %x, got %x", blockRoot, diskRoot)

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -190,7 +190,7 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 	// Pruning is done, now drop the "useless" layers from the snapshot.
 	// Firstly, flushing the target layer into the disk. After that all
 	// diff layers below the target will all be merged into the disk.
-	if err := snaptree.Cap(root, 0); err != nil {
+	if err := snaptree.Cap(root, 0, false); err != nil {
 		return err
 	}
 	// Secondly, flushing the snapshot journal into the disk. All diff

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -39,7 +39,7 @@ var (
 	// Note, bumping this up might drastically increase the size of the bloom
 	// filters that's stored in every diff layer. Don't do that without fully
 	// understanding all the implications.
-	aggregatorMemoryLimit = uint64(10 * 1024)
+	aggregatorMemoryLimit = uint64(4 * 1024 * 1024)
 
 	// aggregatorItemLimit is an approximate number of items that will end up
 	// in the agregator layer before it's flushed out to disk. A plain account
@@ -75,6 +75,9 @@ var (
 	bloomDestructHasherOffset = 0
 	bloomAccountHasherOffset  = 0
 	bloomStorageHasherOffset  = 0
+
+	// A forcing time duration of 10 minutes after which to force a snapshotRoot update
+	defaultSnapRootInterval = 600
 )
 
 func init() {

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -76,8 +76,8 @@ var (
 	bloomAccountHasherOffset  = 0
 	bloomStorageHasherOffset  = 0
 
-	// A forcing time duration of 10 minutes after which to force a snapshotRoot update
-	defaultSnapRootInterval = 600
+	// Count for number of commits before fore disk root update
+	defaultSnapRootCommitThreshold = 100
 )
 
 func init() {

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -76,7 +76,7 @@ var (
 	bloomAccountHasherOffset  = 0
 	bloomStorageHasherOffset  = 0
 
-	// Count for number of commits before fore disk root update
+	// Count for number of commits before forcing disk root update
 	defaultCommitThreshold = 128
 )
 

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -39,7 +39,7 @@ var (
 	// Note, bumping this up might drastically increase the size of the bloom
 	// filters that's stored in every diff layer. Don't do that without fully
 	// understanding all the implications.
-	aggregatorMemoryLimit = uint64(4 * 1024 * 1024)
+	aggregatorMemoryLimit = uint64(10 * 1024)
 
 	// aggregatorItemLimit is an approximate number of items that will end up
 	// in the agregator layer before it's flushed out to disk. A plain account

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -77,7 +77,7 @@ var (
 	bloomStorageHasherOffset  = 0
 
 	// Count for number of commits before fore disk root update
-	defaultSnapRootCommitThreshold = 100
+	defaultCommitThreshold = 128
 )
 
 func init() {

--- a/core/state/snapshot/disklayer_test.go
+++ b/core/state/snapshot/disklayer_test.go
@@ -133,7 +133,7 @@ func TestDiskMerge(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("failed to update snapshot tree: %v", err)
 	}
-	if err := snaps.Cap(diffRoot, 0); err != nil {
+	if err := snaps.Cap(diffRoot, 0, false); err != nil {
 		t.Fatalf("failed to flatten snapshot tree: %v", err)
 	}
 	// Retrieve all the data through the disk layer and validate it
@@ -356,7 +356,7 @@ func TestDiskPartialMerge(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("test %d: failed to update snapshot tree: %v", i, err)
 		}
-		if err := snaps.Cap(diffRoot, 0); err != nil {
+		if err := snaps.Cap(diffRoot, 0, false); err != nil {
 			t.Fatalf("test %d: failed to flatten snapshot tree: %v", i, err)
 		}
 		// Retrieve all the data through the disk layer and validate it
@@ -467,7 +467,7 @@ func TestDiskGeneratorPersistence(t *testing.T) {
 	}, nil); err != nil {
 		t.Fatalf("failed to update snapshot tree: %v", err)
 	}
-	if err := snaps.Cap(diffRoot, 0); err != nil {
+	if err := snaps.Cap(diffRoot, 0, false); err != nil {
 		t.Fatalf("failed to flatten snapshot tree: %v", err)
 	}
 	blob := rawdb.ReadSnapshotGenerator(db)
@@ -489,7 +489,7 @@ func TestDiskGeneratorPersistence(t *testing.T) {
 	}
 	diskLayer := snaps.layers[snaps.diskRoot()].(*diskLayer)
 	diskLayer.genMarker = nil // Construction finished
-	if err := snaps.Cap(diffTwoRoot, 0); err != nil {
+	if err := snaps.Cap(diffTwoRoot, 0, false); err != nil {
 		t.Fatalf("failed to flatten snapshot tree: %v", err)
 	}
 	blob = rawdb.ReadSnapshotGenerator(db)

--- a/core/state/snapshot/iterator_test.go
+++ b/core/state/snapshot/iterator_test.go
@@ -248,7 +248,7 @@ func TestAccountIteratorTraversal(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x04"), 2)
+	snaps.Cap(common.HexToHash("0x04"), 2, false)
 	verifyIterator(t, 7, head.(*diffLayer).newBinaryAccountIterator(), verifyAccount)
 
 	it, _ = snaps.AccountIterator(common.HexToHash("0x04"), common.Hash{})
@@ -296,7 +296,7 @@ func TestStorageIteratorTraversal(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x04"), 2)
+	snaps.Cap(common.HexToHash("0x04"), 2, false)
 	verifyIterator(t, 6, head.(*diffLayer).newBinaryStorageIterator(common.HexToHash("0xaa")), verifyStorage)
 
 	it, _ = snaps.StorageIterator(common.HexToHash("0x04"), common.HexToHash("0xaa"), common.Hash{})
@@ -384,7 +384,7 @@ func TestAccountIteratorTraversalValues(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x09"), 2)
+	snaps.Cap(common.HexToHash("0x09"), 2, false)
 
 	it, _ = snaps.AccountIterator(common.HexToHash("0x09"), common.Hash{})
 	for it.Next() {
@@ -483,7 +483,7 @@ func TestStorageIteratorTraversalValues(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x09"), 2)
+	snaps.Cap(common.HexToHash("0x09"), 2, false)
 
 	it, _ = snaps.StorageIterator(common.HexToHash("0x09"), common.HexToHash("0xaa"), common.Hash{})
 	for it.Next() {
@@ -541,7 +541,7 @@ func TestAccountIteratorLargeTraversal(t *testing.T) {
 		aggregatorMemoryLimit = limit
 	}()
 	aggregatorMemoryLimit = 0 // Force pushing the bottom-most layer into disk
-	snaps.Cap(common.HexToHash("0x80"), 2)
+	snaps.Cap(common.HexToHash("0x80"), 2, false)
 
 	verifyIterator(t, 200, head.(*diffLayer).newBinaryAccountIterator(), verifyAccount)
 
@@ -580,7 +580,7 @@ func TestAccountIteratorFlattening(t *testing.T) {
 	it, _ := snaps.AccountIterator(common.HexToHash("0x04"), common.Hash{})
 	defer it.Release()
 
-	if err := snaps.Cap(common.HexToHash("0x04"), 1); err != nil {
+	if err := snaps.Cap(common.HexToHash("0x04"), 1, false); err != nil {
 		t.Fatalf("failed to flatten snapshot stack: %v", err)
 	}
 	//verifyIterator(t, 7, it)

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -167,11 +167,12 @@ type Config struct {
 // storage data to avoid expensive multi-level trie lookups; and to allow sorted,
 // cheap iteration of the account/storage tries for sync aid.
 type Tree struct {
-	config Config                   // Snapshots configurations
-	diskdb ethdb.KeyValueStore      // Persistent database to store the snapshot
-	triedb *trie.Database           // In-memory cache to access the trie through
-	layers map[common.Hash]snapshot // Collection of all known layers
-	lock   sync.RWMutex
+	config        Config                   // Snapshots configurations
+	diskdb        ethdb.KeyValueStore      // Persistent database to store the snapshot
+	triedb        *trie.Database           // In-memory cache to access the trie through
+	layers        map[common.Hash]snapshot // Collection of all known layers
+	lock          sync.RWMutex
+	commitCounter int // Counter for number of commits
 	// Test hooks
 	onFlatten func() // Hook invoked when the bottom most diff layers are flattened
 }
@@ -862,7 +863,17 @@ func (t *Tree) DiskRoot() common.Hash {
 }
 
 // Checks the config to compare if count of commits is above threshold
-func (t *Tree) CompareThreshold(commitCounts int) bool {
-	log.Debug("Compare counts in snapshots", "count", commitCounts)
-	return (t.config.AllowForceUpdate && (commitCounts > t.config.SnapRootCommitThreshold))
+func (t *Tree) CompareThreshold() bool {
+	if !t.config.AllowForceUpdate {
+		return false
+	}
+	log.Debug("Commit counters", "counter", t.commitCounter, "threshold", t.config.SnapRootCommitThreshold)
+	if t.commitCounter > t.config.SnapRootCommitThreshold {
+		t.commitCounter = 0
+		return true
+	}
+
+	t.commitCounter++
+
+	return false
 }

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -155,7 +155,7 @@ type Config struct {
 	NoBuild                bool // Indicator that the snapshots generation is disallowed
 	AsyncBuild             bool // The snapshot generation is allowed to be constructed asynchronously
 	EnableSnapRootInterval bool // Enable forcing snap root generation on an interval
-	SnapRootInterval       int  // Time in seconds after which to force a snapshot update
+	SnapRootThreshold      int  // Time in seconds after which to force a snapshot update
 }
 
 // Tree is an Ethereum state snapshot tree. It consists of one persistent base
@@ -173,7 +173,7 @@ type Tree struct {
 	triedb   *trie.Database           // In-memory cache to access the trie through
 	layers   map[common.Hash]snapshot // Collection of all known layers
 	lock     sync.RWMutex
-	baseTime time.Time // Base time when the tree was started/restarted
+	baseTime time.Time // Base time to calculate snap root interval
 	// Test hooks
 	onFlatten func() // Hook invoked when the bottom most diff layers are flattened
 }
@@ -204,10 +204,10 @@ func New(config Config, diskdb ethdb.KeyValueStore, triedb *trie.Database, root 
 		baseTime: time.Now(),
 	}
 
-	// Setting the default interval value if it is enabled
-	// Important to set it to default value if enabled to avoid update every block
-	if config.EnableSnapRootInterval && (config.SnapRootInterval == 0) {
-		snap.config.SnapRootInterval = defaultSnapRootInterval
+	// Setting the default interval value if it is enabled and not set
+	// Important to set it to at least default value if enabled to avoid update snap root very aggressively
+	if config.EnableSnapRootInterval && (config.SnapRootThreshold < defaultSnapRootInterval) {
+		snap.config.SnapRootThreshold = defaultSnapRootInterval
 	}
 
 	// Attempt to load a previously persisted snapshot and rebuild one if failed
@@ -386,7 +386,6 @@ func (t *Tree) Update(blockRoot common.Hash, parentRoot common.Hash, destructs m
 // we want to ensure that *at least* the requested number of diff layers remain.
 func (t *Tree) Cap(root common.Hash, layers int) error {
 	// Retrieve the head snapshot to cap from
-	log.Debug("Cap snap tree", "root", root, "layers", layers)
 	snap := t.Snapshot(root)
 	if snap == nil {
 		return fmt.Errorf("snapshot [%#x] missing", root)
@@ -470,7 +469,6 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 // survival is only known *after* capping, we need to omit it from the count if
 // we want to ensure that *at least* the requested number of diff layers remain.
 func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
-	log.Debug("Tree cap internal layer")
 	// Dive until we run out of layers or reach the persistent database
 	for i := 0; i < layers-1; i++ {
 		// If we still have diff layers below, continue down
@@ -486,11 +484,9 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 	// the memory limit is not yet exceeded.
 	switch parent := diff.parent.(type) {
 	case *diskLayer:
-		log.Debug("Tree Parent case", "type", "disklayer", "parent", parent)
 		return nil
 
 	case *diffLayer:
-		log.Debug("Tree Parent case", "type", "difflayer", "parent", parent)
 		// Hold the write lock until the flattened parent is linked correctly.
 		// Otherwise, the stale layer may be accessed by external reads in the
 		// meantime.
@@ -509,9 +505,9 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 		diff.parent = flattened
 		// Check if we are above the interval time if it is enabled
 		timeFromLastSnap := time.Now().Sub(t.baseTime).Seconds()
-		forceSnapshot := (t.config.EnableSnapRootInterval && (int(timeFromLastSnap) >= t.config.SnapRootInterval))
+		forceSnapshot := (t.config.EnableSnapRootInterval && (int(timeFromLastSnap) >= t.config.SnapRootThreshold))
 
-		log.Debug("Flattened Memory Limit", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "timeThreshold", t.config.SnapRootInterval, "timePassed", timeFromLastSnap, "forceSnapshot", forceSnapshot)
+		log.Debug("Validating snapRoot update", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "timeThreshold", common.PrettyDuration(t.config.SnapRootThreshold), "elapsed", common.PrettyDuration(timeFromLastSnap), "forceSnapshot", forceSnapshot)
 		if (flattened.memory < aggregatorMemoryLimit) && !forceSnapshot {
 			// Accumulator layer is smaller than the limit, so we can abort, unless
 			// there's a snapshot being generated currently. In that case, the trie
@@ -519,7 +515,6 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 			// partial data down into the snapshot and restart the generation.
 			// or time interval has been crossed to force a snapshot
 			if flattened.parent.(*diskLayer).genAbort == nil {
-				log.Debug("Returning from cap")
 				return nil
 			}
 		}
@@ -529,7 +524,6 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 	// If the bottom-most layer is larger than our memory cap, persist to disk
 	bottom := diff.parent.(*diffLayer)
 	bottom.lock.RLock()
-	log.Debug("Going into diffToDisk")
 	base := diffToDisk(bottom)
 	bottom.lock.RUnlock()
 	// resetting the baseTime
@@ -545,7 +539,6 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 // The disk layer persistence should be operated in an atomic way. All updates should
 // be discarded if the whole transition if not finished.
 func diffToDisk(bottom *diffLayer) *diskLayer {
-	log.Debug("Checking Diff to disk")
 	var (
 		base  = bottom.parent.(*diskLayer)
 		batch = base.diskdb.NewBatch()
@@ -558,7 +551,6 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		stats = <-abort
 	}
 	// Put the deletion in the batch writer, flush all updates in the final step.
-	log.Debug("Deleting Snapshot")
 	rawdb.DeleteSnapshotRoot(batch)
 
 	// Mark the original base as stale as we're going to create a new wrapper
@@ -570,7 +562,6 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 	base.lock.Unlock()
 
 	// Destroy all the destructed accounts from the database
-	log.Debug("Destroy account from database")
 	for hash := range bottom.destructSet {
 		// Skip any account not covered yet by the snapshot
 		if base.genMarker != nil && bytes.Compare(hash[:], base.genMarker) > 0 {
@@ -591,7 +582,6 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			// huge). It's ok to flush, the root will go missing in case of a
 			// crash and we'll detect and regenerate the snapshot.
 			if batch.ValueSize() > ethdb.IdealBatchSize {
-				log.Debug("Write batch")
 				if err := batch.Write(); err != nil {
 					log.Crit("Failed to write storage deletions", "err", err)
 				}
@@ -601,7 +591,6 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		it.Release()
 	}
 	// Push all updated accounts into the database
-	log.Debug("Push Update account from database")
 	for hash, data := range bottom.accountData {
 		// Skip any account not covered yet by the snapshot
 		if base.genMarker != nil && bytes.Compare(hash[:], base.genMarker) > 0 {
@@ -619,7 +608,6 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		// root will go missing in case of a crash and we'll detect and regen
 		// the snapshot.
 		if batch.ValueSize() > ethdb.IdealBatchSize {
-			log.Debug("Write account batch")
 			if err := batch.Write(); err != nil {
 				log.Crit("Failed to write storage deletions", "err", err)
 			}
@@ -652,11 +640,8 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			snapshotFlushStorageSizeMeter.Mark(int64(len(data)))
 		}
 	}
-	log.Debug("At write snapshot point", "bottom", bottom.root)
 	// Update the snapshot block marker and write any remainder data
 	rawdb.WriteSnapshotRoot(batch, bottom.root)
-
-	log.Debug("Snapshot Write complete")
 
 	// Write out the generator progress marker and report
 	journalProgress(batch, base.genMarker, stats)
@@ -666,7 +651,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to write leftover snapshot", "err", err)
 	}
-	log.Debug("Journalled disk layer", "root", bottom.root, "complete", base.genMarker == nil)
+	log.Debug("Snapshot Root generation complete", "newSnapRoot", bottom.root)
 	res := &diskLayer{
 		root:       bottom.root,
 		cache:      base.cache,

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -149,12 +149,24 @@ type snapshot interface {
 
 // Config includes the configurations for snapshots.
 type Config struct {
-	CacheSize               int  // Megabytes permitted to use for read caches
-	Recovery                bool // Indicator that the snapshots is in the recovery mode
-	NoBuild                 bool // Indicator that the snapshots generation is disallowed
-	AsyncBuild              bool // The snapshot generation is allowed to be constructed asynchronously
-	AllowForceUpdate        bool // Enable forcing snap root generation on a commit count
-	SnapRootCommitThreshold int  // Number of commit after which to attempt snap root update
+	CacheSize        int  // Megabytes permitted to use for read caches
+	Recovery         bool // Indicator that the snapshots is in the recovery mode
+	NoBuild          bool // Indicator that the snapshots generation is disallowed
+	AsyncBuild       bool // The snapshot generation is allowed to be constructed asynchronously
+	AllowForceUpdate bool // Enable forcing snap root generation on a commit count
+	CommitThreshold  int  // Number of commit after which to attempt snap root update
+}
+
+// sanitize checks the provided user configurations and changes anything that's
+// unreasonable or unworkable.
+func (c *Config) sanitize() Config {
+	conf := *c
+
+	if conf.CommitThreshold == 0 {
+		log.Warn("Sanitizing invalid commit threshold to default", "defaultThreshold", defaultCommitThreshold)
+		conf.CommitThreshold = defaultCommitThreshold
+	}
+	return conf
 }
 
 // Tree is an Ethereum state snapshot tree. It consists of one persistent base
@@ -194,18 +206,15 @@ type Tree struct {
 //   - otherwise, the entire snapshot is considered invalid and will be recreated on
 //     a background thread.
 func New(config Config, diskdb ethdb.KeyValueStore, triedb *trie.Database, root common.Hash) (*Tree, error) {
+	// apply default to config and fix invalid values
+	conf := config.sanitize()
+
 	// Create a new, empty snapshot tree
 	snap := &Tree{
-		config: config,
+		config: conf,
 		diskdb: diskdb,
 		triedb: triedb,
 		layers: make(map[common.Hash]snapshot),
-	}
-
-	// Setting the default interval value if it is enabled and not set
-	// Important to set it to at least default value if enabled to avoid update snap root very aggressively
-	if config.AllowForceUpdate && (config.SnapRootCommitThreshold == 0) {
-		snap.config.SnapRootCommitThreshold = defaultSnapRootCommitThreshold
 	}
 
 	// Attempt to load a previously persisted snapshot and rebuild one if failed
@@ -501,7 +510,7 @@ func (t *Tree) cap(diff *diffLayer, layers int, force bool) *diskLayer {
 			t.onFlatten()
 		}
 		diff.parent = flattened
-		log.Debug("Validating snapRoot update", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "commitThreshold", t.config.SnapRootCommitThreshold, "forceSnapshot", force)
+		log.Debug("Validating snapRoot update", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "commitThreshold", t.config.CommitThreshold, "forceSnapshot", force)
 		if (flattened.memory < aggregatorMemoryLimit) && !force {
 			// Accumulator layer is smaller than the limit, so we can abort, unless
 			// there's a snapshot being generated currently. In that case, the trie
@@ -867,8 +876,8 @@ func (t *Tree) CompareThreshold() bool {
 	if !t.config.AllowForceUpdate {
 		return false
 	}
-	log.Debug("Commit counters", "counter", t.commitCounter, "threshold", t.config.SnapRootCommitThreshold)
-	if t.commitCounter > t.config.SnapRootCommitThreshold {
+	log.Debug("Snapshot Commit counters", "counter", t.commitCounter, "threshold", t.config.CommitThreshold)
+	if t.commitCounter > t.config.CommitThreshold {
 		t.commitCounter = 0
 		return true
 	}

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -150,12 +149,12 @@ type snapshot interface {
 
 // Config includes the configurations for snapshots.
 type Config struct {
-	CacheSize              int  // Megabytes permitted to use for read caches
-	Recovery               bool // Indicator that the snapshots is in the recovery mode
-	NoBuild                bool // Indicator that the snapshots generation is disallowed
-	AsyncBuild             bool // The snapshot generation is allowed to be constructed asynchronously
-	EnableSnapRootInterval bool // Enable forcing snap root generation on an interval
-	SnapRootThreshold      int  // Time in seconds after which to force a snapshot update
+	CacheSize               int  // Megabytes permitted to use for read caches
+	Recovery                bool // Indicator that the snapshots is in the recovery mode
+	NoBuild                 bool // Indicator that the snapshots generation is disallowed
+	AsyncBuild              bool // The snapshot generation is allowed to be constructed asynchronously
+	AllowForceUpdate        bool // Enable forcing snap root generation on a commit count
+	SnapRootCommitThreshold int  // Number of commit after which to attempt snap root update
 }
 
 // Tree is an Ethereum state snapshot tree. It consists of one persistent base
@@ -168,12 +167,11 @@ type Config struct {
 // storage data to avoid expensive multi-level trie lookups; and to allow sorted,
 // cheap iteration of the account/storage tries for sync aid.
 type Tree struct {
-	config   Config                   // Snapshots configurations
-	diskdb   ethdb.KeyValueStore      // Persistent database to store the snapshot
-	triedb   *trie.Database           // In-memory cache to access the trie through
-	layers   map[common.Hash]snapshot // Collection of all known layers
-	lock     sync.RWMutex
-	baseTime time.Time // Base time to calculate snap root interval
+	config Config                   // Snapshots configurations
+	diskdb ethdb.KeyValueStore      // Persistent database to store the snapshot
+	triedb *trie.Database           // In-memory cache to access the trie through
+	layers map[common.Hash]snapshot // Collection of all known layers
+	lock   sync.RWMutex
 	// Test hooks
 	onFlatten func() // Hook invoked when the bottom most diff layers are flattened
 }
@@ -197,17 +195,16 @@ type Tree struct {
 func New(config Config, diskdb ethdb.KeyValueStore, triedb *trie.Database, root common.Hash) (*Tree, error) {
 	// Create a new, empty snapshot tree
 	snap := &Tree{
-		config:   config,
-		diskdb:   diskdb,
-		triedb:   triedb,
-		layers:   make(map[common.Hash]snapshot),
-		baseTime: time.Now(),
+		config: config,
+		diskdb: diskdb,
+		triedb: triedb,
+		layers: make(map[common.Hash]snapshot),
 	}
 
 	// Setting the default interval value if it is enabled and not set
 	// Important to set it to at least default value if enabled to avoid update snap root very aggressively
-	if config.EnableSnapRootInterval && (config.SnapRootThreshold < defaultSnapRootInterval) {
-		snap.config.SnapRootThreshold = defaultSnapRootInterval
+	if config.AllowForceUpdate && (config.SnapRootCommitThreshold == 0) {
+		snap.config.SnapRootCommitThreshold = defaultSnapRootCommitThreshold
 	}
 
 	// Attempt to load a previously persisted snapshot and rebuild one if failed
@@ -384,7 +381,7 @@ func (t *Tree) Update(blockRoot common.Hash, parentRoot common.Hash, destructs m
 // which may or may not overflow and cascade to disk. Since this last layer's
 // survival is only known *after* capping, we need to omit it from the count if
 // we want to ensure that *at least* the requested number of diff layers remain.
-func (t *Tree) Cap(root common.Hash, layers int) error {
+func (t *Tree) Cap(root common.Hash, layers int, force bool) error {
 	// Retrieve the head snapshot to cap from
 	snap := t.Snapshot(root)
 	if snap == nil {
@@ -418,7 +415,7 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 		t.layers = map[common.Hash]snapshot{base.root: base}
 		return nil
 	}
-	persisted := t.cap(diff, layers)
+	persisted := t.cap(diff, layers, force)
 
 	// Remove any layer that is stale or links into a stale layer
 	children := make(map[common.Hash][]common.Hash)
@@ -468,7 +465,7 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 // which may or may not overflow and cascade to disk. Since this last layer's
 // survival is only known *after* capping, we need to omit it from the count if
 // we want to ensure that *at least* the requested number of diff layers remain.
-func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
+func (t *Tree) cap(diff *diffLayer, layers int, force bool) *diskLayer {
 	// Dive until we run out of layers or reach the persistent database
 	for i := 0; i < layers-1; i++ {
 		// If we still have diff layers below, continue down
@@ -503,12 +500,8 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 			t.onFlatten()
 		}
 		diff.parent = flattened
-		// Check if we are above the interval time if it is enabled
-		timeFromLastSnap := time.Now().Sub(t.baseTime).Seconds()
-		forceSnapshot := (t.config.EnableSnapRootInterval && (int(timeFromLastSnap) >= t.config.SnapRootThreshold))
-
-		log.Debug("Validating snapRoot update", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "timeThreshold", common.PrettySeconds(t.config.SnapRootThreshold), "elapsed", common.PrettySeconds(timeFromLastSnap), "forceSnapshot", forceSnapshot)
-		if (flattened.memory < aggregatorMemoryLimit) && !forceSnapshot {
+		log.Debug("Validating snapRoot update", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "commitThreshold", t.config.SnapRootCommitThreshold, "forceSnapshot", force)
+		if (flattened.memory < aggregatorMemoryLimit) && !force {
 			// Accumulator layer is smaller than the limit, so we can abort, unless
 			// there's a snapshot being generated currently. In that case, the trie
 			// will move from underneath the generator so we **must** merge all the
@@ -526,8 +519,6 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 	bottom.lock.RLock()
 	base := diffToDisk(bottom)
 	bottom.lock.RUnlock()
-	// resetting the baseTime
-	t.baseTime = time.Now()
 	t.layers[base.root] = base
 	diff.parent = base
 	return base
@@ -868,4 +859,10 @@ func (t *Tree) DiskRoot() common.Hash {
 	defer t.lock.Unlock()
 
 	return t.diskRoot()
+}
+
+// Checks the config to compare if count of commits is above threshold
+func (t *Tree) CompareThreshold(commitCounts int) bool {
+	log.Debug("Compare counts in snapshots", "count", commitCounts)
+	return (t.config.AllowForceUpdate && (commitCounts > t.config.SnapRootCommitThreshold))
 }

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -375,6 +375,7 @@ func (t *Tree) Update(blockRoot common.Hash, parentRoot common.Hash, destructs m
 // we want to ensure that *at least* the requested number of diff layers remain.
 func (t *Tree) Cap(root common.Hash, layers int) error {
 	// Retrieve the head snapshot to cap from
+	log.Debug("Cap snap tree", "root", root, "layers", layers)
 	snap := t.Snapshot(root)
 	if snap == nil {
 		return fmt.Errorf("snapshot [%#x] missing", root)
@@ -458,6 +459,7 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 // survival is only known *after* capping, we need to omit it from the count if
 // we want to ensure that *at least* the requested number of diff layers remain.
 func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
+	log.Debug("Tree cap internal layer")
 	// Dive until we run out of layers or reach the persistent database
 	for i := 0; i < layers-1; i++ {
 		// If we still have diff layers below, continue down
@@ -465,6 +467,7 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 			diff = parent
 		} else {
 			// Diff stack too shallow, return without modifications
+			log.Debug("Diff layer too shallow. No Modification", "count", i, "layers", layers)
 			return nil
 		}
 	}
@@ -472,9 +475,11 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 	// the memory limit is not yet exceeded.
 	switch parent := diff.parent.(type) {
 	case *diskLayer:
+		log.Debug("Tree Parent case", "type", "disklayer", "parent", parent)
 		return nil
 
 	case *diffLayer:
+		log.Debug("Tree Parent case", "type", "difflayer", "parent", parent)
 		// Hold the write lock until the flattened parent is linked correctly.
 		// Otherwise, the stale layer may be accessed by external reads in the
 		// meantime.
@@ -491,12 +496,14 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 			t.onFlatten()
 		}
 		diff.parent = flattened
+		log.Debug("Flattened Memory Limit", "limit", aggregatorMemoryLimit, "current", flattened.memory)
 		if flattened.memory < aggregatorMemoryLimit {
 			// Accumulator layer is smaller than the limit, so we can abort, unless
 			// there's a snapshot being generated currently. In that case, the trie
 			// will move from underneath the generator so we **must** merge all the
 			// partial data down into the snapshot and restart the generation.
 			if flattened.parent.(*diskLayer).genAbort == nil {
+				log.Debug("Returning from cap")
 				return nil
 			}
 		}
@@ -507,6 +514,7 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 	bottom := diff.parent.(*diffLayer)
 
 	bottom.lock.RLock()
+	log.Debug("Going into diffToDisk")
 	base := diffToDisk(bottom)
 	bottom.lock.RUnlock()
 
@@ -521,6 +529,7 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 // The disk layer persistence should be operated in an atomic way. All updates should
 // be discarded if the whole transition if not finished.
 func diffToDisk(bottom *diffLayer) *diskLayer {
+	log.Debug("Checking Diff to disk")
 	var (
 		base  = bottom.parent.(*diskLayer)
 		batch = base.diskdb.NewBatch()
@@ -533,6 +542,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		stats = <-abort
 	}
 	// Put the deletion in the batch writer, flush all updates in the final step.
+	log.Debug("Deleting Snapshot")
 	rawdb.DeleteSnapshotRoot(batch)
 
 	// Mark the original base as stale as we're going to create a new wrapper
@@ -544,6 +554,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 	base.lock.Unlock()
 
 	// Destroy all the destructed accounts from the database
+	log.Debug("Destroy account from database")
 	for hash := range bottom.destructSet {
 		// Skip any account not covered yet by the snapshot
 		if base.genMarker != nil && bytes.Compare(hash[:], base.genMarker) > 0 {
@@ -564,6 +575,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			// huge). It's ok to flush, the root will go missing in case of a
 			// crash and we'll detect and regenerate the snapshot.
 			if batch.ValueSize() > ethdb.IdealBatchSize {
+				log.Debug("Write batch")
 				if err := batch.Write(); err != nil {
 					log.Crit("Failed to write storage deletions", "err", err)
 				}
@@ -573,6 +585,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		it.Release()
 	}
 	// Push all updated accounts into the database
+	log.Debug("Push Update account from database")
 	for hash, data := range bottom.accountData {
 		// Skip any account not covered yet by the snapshot
 		if base.genMarker != nil && bytes.Compare(hash[:], base.genMarker) > 0 {
@@ -590,6 +603,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		// root will go missing in case of a crash and we'll detect and regen
 		// the snapshot.
 		if batch.ValueSize() > ethdb.IdealBatchSize {
+			log.Debug("Write account batch")
 			if err := batch.Write(); err != nil {
 				log.Crit("Failed to write storage deletions", "err", err)
 			}
@@ -622,8 +636,11 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			snapshotFlushStorageSizeMeter.Mark(int64(len(data)))
 		}
 	}
+	log.Debug("At write snapshot point", "bottom", bottom.root)
 	// Update the snapshot block marker and write any remainder data
 	rawdb.WriteSnapshotRoot(batch, bottom.root)
+
+	log.Debug("Snapshot Write complete")
 
 	// Write out the generator progress marker and report
 	journalProgress(batch, base.genMarker, stats)

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -153,8 +153,8 @@ type Config struct {
 	Recovery         bool // Indicator that the snapshots is in the recovery mode
 	NoBuild          bool // Indicator that the snapshots generation is disallowed
 	AsyncBuild       bool // The snapshot generation is allowed to be constructed asynchronously
-	AllowForceUpdate bool // Enable forcing snap root generation on a commit count
-	CommitThreshold  int  // Number of commit after which to attempt snap root update
+	AllowForceUpdate bool // Enable to force root snapshots based on the configured commits threshold
+	CommitThreshold  int  // Threshold of commits to force a root snapshot update
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -163,7 +163,7 @@ func (c *Config) sanitize() Config {
 	conf := *c
 
 	if conf.CommitThreshold == 0 {
-		log.Warn("Sanitizing invalid commit threshold to default", "defaultThreshold", defaultCommitThreshold)
+		log.Warn("Sanitizing commit threshold", "provided", conf.CommitThreshold, "updated", defaultCommitThreshold)
 		conf.CommitThreshold = defaultCommitThreshold
 	}
 	return conf
@@ -206,12 +206,10 @@ type Tree struct {
 //   - otherwise, the entire snapshot is considered invalid and will be recreated on
 //     a background thread.
 func New(config Config, diskdb ethdb.KeyValueStore, triedb *trie.Database, root common.Hash) (*Tree, error) {
-	// apply default to config and fix invalid values
-	conf := config.sanitize()
 
 	// Create a new, empty snapshot tree
 	snap := &Tree{
-		config: conf,
+		config: config.sanitize(),
 		diskdb: diskdb,
 		triedb: triedb,
 		layers: make(map[common.Hash]snapshot),

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -149,10 +150,12 @@ type snapshot interface {
 
 // Config includes the configurations for snapshots.
 type Config struct {
-	CacheSize  int  // Megabytes permitted to use for read caches
-	Recovery   bool // Indicator that the snapshots is in the recovery mode
-	NoBuild    bool // Indicator that the snapshots generation is disallowed
-	AsyncBuild bool // The snapshot generation is allowed to be constructed asynchronously
+	CacheSize              int  // Megabytes permitted to use for read caches
+	Recovery               bool // Indicator that the snapshots is in the recovery mode
+	NoBuild                bool // Indicator that the snapshots generation is disallowed
+	AsyncBuild             bool // The snapshot generation is allowed to be constructed asynchronously
+	EnableSnapRootInterval bool // Enable forcing snap root generation on an interval
+	SnapRootInterval       int  // Time in seconds after which to force a snapshot update
 }
 
 // Tree is an Ethereum state snapshot tree. It consists of one persistent base
@@ -165,12 +168,12 @@ type Config struct {
 // storage data to avoid expensive multi-level trie lookups; and to allow sorted,
 // cheap iteration of the account/storage tries for sync aid.
 type Tree struct {
-	config Config                   // Snapshots configurations
-	diskdb ethdb.KeyValueStore      // Persistent database to store the snapshot
-	triedb *trie.Database           // In-memory cache to access the trie through
-	layers map[common.Hash]snapshot // Collection of all known layers
-	lock   sync.RWMutex
-
+	config   Config                   // Snapshots configurations
+	diskdb   ethdb.KeyValueStore      // Persistent database to store the snapshot
+	triedb   *trie.Database           // In-memory cache to access the trie through
+	layers   map[common.Hash]snapshot // Collection of all known layers
+	lock     sync.RWMutex
+	baseTime time.Time // Base time when the tree was started/restarted
 	// Test hooks
 	onFlatten func() // Hook invoked when the bottom most diff layers are flattened
 }
@@ -194,11 +197,19 @@ type Tree struct {
 func New(config Config, diskdb ethdb.KeyValueStore, triedb *trie.Database, root common.Hash) (*Tree, error) {
 	// Create a new, empty snapshot tree
 	snap := &Tree{
-		config: config,
-		diskdb: diskdb,
-		triedb: triedb,
-		layers: make(map[common.Hash]snapshot),
+		config:   config,
+		diskdb:   diskdb,
+		triedb:   triedb,
+		layers:   make(map[common.Hash]snapshot),
+		baseTime: time.Now(),
 	}
+
+	// Setting the default interval value if it is enabled
+	// Important to set it to default value if enabled to avoid update every block
+	if config.EnableSnapRootInterval && (config.SnapRootInterval == 0) {
+		snap.config.SnapRootInterval = defaultSnapRootInterval
+	}
+
 	// Attempt to load a previously persisted snapshot and rebuild one if failed
 	head, disabled, err := loadSnapshot(diskdb, triedb, root, config.CacheSize, config.Recovery, config.NoBuild)
 	if disabled {
@@ -496,12 +507,17 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 			t.onFlatten()
 		}
 		diff.parent = flattened
-		log.Debug("Flattened Memory Limit", "limit", aggregatorMemoryLimit, "current", flattened.memory)
-		if flattened.memory < aggregatorMemoryLimit {
+		// Check if we are above the interval time if it is enabled
+		timeFromLastSnap := time.Now().Sub(t.baseTime).Seconds()
+		forceSnapshot := (t.config.EnableSnapRootInterval && (int(timeFromLastSnap) >= t.config.SnapRootInterval))
+
+		log.Debug("Flattened Memory Limit", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "timeThreshold", t.config.SnapRootInterval, "timePassed", timeFromLastSnap, "forceSnapshot", forceSnapshot)
+		if (flattened.memory < aggregatorMemoryLimit) && !forceSnapshot {
 			// Accumulator layer is smaller than the limit, so we can abort, unless
 			// there's a snapshot being generated currently. In that case, the trie
 			// will move from underneath the generator so we **must** merge all the
 			// partial data down into the snapshot and restart the generation.
+			// or time interval has been crossed to force a snapshot
 			if flattened.parent.(*diskLayer).genAbort == nil {
 				log.Debug("Returning from cap")
 				return nil
@@ -512,12 +528,12 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 	}
 	// If the bottom-most layer is larger than our memory cap, persist to disk
 	bottom := diff.parent.(*diffLayer)
-
 	bottom.lock.RLock()
 	log.Debug("Going into diffToDisk")
 	base := diffToDisk(bottom)
 	bottom.lock.RUnlock()
-
+	// resetting the baseTime
+	t.baseTime = time.Now()
 	t.layers[base.root] = base
 	diff.parent = base
 	return base

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -507,7 +507,7 @@ func (t *Tree) cap(diff *diffLayer, layers int) *diskLayer {
 		timeFromLastSnap := time.Now().Sub(t.baseTime).Seconds()
 		forceSnapshot := (t.config.EnableSnapRootInterval && (int(timeFromLastSnap) >= t.config.SnapRootThreshold))
 
-		log.Debug("Validating snapRoot update", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "timeThreshold", common.PrettyDuration(t.config.SnapRootThreshold), "elapsed", common.PrettyDuration(timeFromLastSnap), "forceSnapshot", forceSnapshot)
+		log.Debug("Validating snapRoot update", "limit", aggregatorMemoryLimit, "currentMemory", flattened.memory, "timeThreshold", common.PrettySeconds(t.config.SnapRootThreshold), "elapsed", common.PrettySeconds(timeFromLastSnap), "forceSnapshot", forceSnapshot)
 		if (flattened.memory < aggregatorMemoryLimit) && !forceSnapshot {
 			// Accumulator layer is smaller than the limit, so we can abort, unless
 			// there's a snapshot being generated currently. In that case, the trie

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -115,7 +115,7 @@ func TestDiskLayerExternalInvalidationFullFlatten(t *testing.T) {
 		t.Errorf("pre-cap layer count mismatch: have %d, want %d", n, 2)
 	}
 	// Commit the diff layer onto the disk and ensure it's persisted
-	if err := snaps.Cap(common.HexToHash("0x02"), 0); err != nil {
+	if err := snaps.Cap(common.HexToHash("0x02"), 0, false); err != nil {
 		t.Fatalf("failed to merge diff layer onto disk: %v", err)
 	}
 	// Since the base layer was modified, ensure that data retrievals on the external reference fail
@@ -165,7 +165,7 @@ func TestDiskLayerExternalInvalidationPartialFlatten(t *testing.T) {
 	defer func(memcap uint64) { aggregatorMemoryLimit = memcap }(aggregatorMemoryLimit)
 	aggregatorMemoryLimit = 0
 
-	if err := snaps.Cap(common.HexToHash("0x03"), 1); err != nil {
+	if err := snaps.Cap(common.HexToHash("0x03"), 1, false); err != nil {
 		t.Fatalf("failed to merge accumulator onto disk: %v", err)
 	}
 	// Since the base layer was modified, ensure that data retrievals on the external reference fail
@@ -216,14 +216,14 @@ func TestDiffLayerExternalInvalidationPartialFlatten(t *testing.T) {
 
 	// Doing a Cap operation with many allowed layers should be a no-op
 	exp := len(snaps.layers)
-	if err := snaps.Cap(common.HexToHash("0x04"), 2000); err != nil {
+	if err := snaps.Cap(common.HexToHash("0x04"), 2000, false); err != nil {
 		t.Fatalf("failed to flatten diff layer into accumulator: %v", err)
 	}
 	if got := len(snaps.layers); got != exp {
 		t.Errorf("layers modified, got %d exp %d", got, exp)
 	}
 	// Flatten the diff layer into the bottom accumulator
-	if err := snaps.Cap(common.HexToHash("0x04"), 1); err != nil {
+	if err := snaps.Cap(common.HexToHash("0x04"), 1, false); err != nil {
 		t.Fatalf("failed to flatten diff layer into accumulator: %v", err)
 	}
 	// Since the accumulator diff layer was modified, ensure that data retrievals on the external reference fail
@@ -294,11 +294,11 @@ func TestPostCapBasicDataAccess(t *testing.T) {
 		t.Error(err)
 	}
 	// Cap to a bad root should fail
-	if err := snaps.Cap(common.HexToHash("0x1337"), 0); err == nil {
+	if err := snaps.Cap(common.HexToHash("0x1337"), 0, false); err == nil {
 		t.Errorf("expected error, got none")
 	}
 	// Now, merge the a-chain
-	snaps.Cap(common.HexToHash("0xa3"), 0)
+	snaps.Cap(common.HexToHash("0xa3"), 0, false)
 
 	// At this point, a2 got merged into a1. Thus, a1 is now modified, and as a1 is
 	// the parent of b2, b2 should no longer be able to iterate into parent.
@@ -322,7 +322,7 @@ func TestPostCapBasicDataAccess(t *testing.T) {
 	}
 	// Now, merge it again, just for fun. It should now error, since a3
 	// is a disk layer
-	if err := snaps.Cap(common.HexToHash("0xa3"), 0); err == nil {
+	if err := snaps.Cap(common.HexToHash("0xa3"), 0, false); err == nil {
 		t.Error("expected error capping the disk layer, got none")
 	}
 }
@@ -354,11 +354,24 @@ func TestForceSnapRootCaps(t *testing.T) {
 		layers: map[common.Hash]snapshot{
 			base.root: base,
 		},
-		baseTime: time.Now(),
 		config: Config{
-			EnableSnapRootInterval: true,
-			SnapRootThreshold:      300,
+			SnapRootCommitThreshold: 10,
 		},
+	}
+
+	// validate compareThreshold method when disabled
+	if compare := snaps.CompareThreshold(100); compare {
+		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: false", compare)
+	}
+
+	// validate compareThreshold method when enabled
+	snaps.config.AllowForceUpdate = true
+	if compare := snaps.CompareThreshold(5); compare {
+		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: false", compare)
+	}
+
+	if compare := snaps.CompareThreshold(20); !compare {
+		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: true", compare)
 	}
 
 	// adding layers to the tree more than 128
@@ -374,7 +387,7 @@ func TestForceSnapRootCaps(t *testing.T) {
 	}
 
 	// Now capping without time threshold reached
-	if err := snaps.Cap(head, 128); err != nil {
+	if err := snaps.Cap(head, 128, false); err != nil {
 		t.Error("Error while capping layers", err)
 	}
 
@@ -390,12 +403,8 @@ func TestForceSnapRootCaps(t *testing.T) {
 		t.Errorf("Unexpected number of layers after flatten - count: %d, expected: 130", newLayers)
 	}
 
-	// Setting baseTime 10 min behind to trigger forceSnapshot
-	snaps.baseTime = time.Now().Add(time.Duration(-10) * time.Minute)
-
-	// Check if forceSnapshot disabled, time threshold should not trigger snapshot
-	snaps.config.EnableSnapRootInterval = false
-	if err := snaps.Cap(head, 128); err != nil {
+	// Check if forceSnapshot disabled, disk root should not update
+	if err := snaps.Cap(head, 128, false); err != nil {
 		t.Error("Error while capping layers", err)
 	}
 
@@ -405,9 +414,8 @@ func TestForceSnapRootCaps(t *testing.T) {
 		t.Errorf("Disk root should not have updated at this point - actual: %s, expected: %s", firstDiskRoot, base.root)
 	}
 
-	// Re-enable forceSnapshot, time threshold should trigger snapshot
-	snaps.config.EnableSnapRootInterval = true
-	if err := snaps.Cap(head, 128); err != nil {
+	// Re-enable forceSnapshot, disk root should update now
+	if err := snaps.Cap(head, 128, true); err != nil {
 		t.Error("Error while capping layers", err)
 	}
 
@@ -459,7 +467,7 @@ func TestSnaphots(t *testing.T) {
 		head = makeRoot(uint64(i + 2))
 		snaps.Update(head, last, nil, setAccount(fmt.Sprintf("%d", i+2)), nil)
 		last = head
-		snaps.Cap(head, 128) // 130 layers (128 diffs + 1 accumulator + 1 disk)
+		snaps.Cap(head, 128, false) // 130 layers (128 diffs + 1 accumulator + 1 disk)
 	}
 	var cases = []struct {
 		headRoot     common.Hash
@@ -494,7 +502,7 @@ func TestSnaphots(t *testing.T) {
 	defer func(memcap uint64) { aggregatorMemoryLimit = memcap }(aggregatorMemoryLimit)
 	aggregatorMemoryLimit = 0
 
-	snaps.Cap(head, 128) // 129 (128 diffs + 1 overflown accumulator + 1 disk)
+	snaps.Cap(head, 128, false) // 129 (128 diffs + 1 overflown accumulator + 1 disk)
 
 	cases = []struct {
 		headRoot     common.Hash
@@ -573,7 +581,7 @@ func TestReadStateDuringFlattening(t *testing.T) {
 		}
 	}
 	// Cap the snap tree, which will mark the bottom-most layer as stale.
-	snaps.Cap(common.HexToHash("0xa3"), 1)
+	snaps.Cap(common.HexToHash("0xa3"), 1, false)
 	select {
 	case account := <-result:
 		if account == nil {

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -355,8 +355,8 @@ func TestForceSnapRootCaps(t *testing.T) {
 			base.root: base,
 		},
 		config: Config{
-			AllowForceUpdate:        true,
-			SnapRootCommitThreshold: 10,
+			AllowForceUpdate: true,
+			CommitThreshold:  10,
 		},
 	}
 

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -327,6 +327,103 @@ func TestPostCapBasicDataAccess(t *testing.T) {
 	}
 }
 
+func TestForceSnapRootCaps(t *testing.T) {
+	// setAccount is a helper to construct a random account entry and assign it to
+	// an account slot in a snapshot
+	setAccount := func(accKey string) map[common.Hash][]byte {
+		return map[common.Hash][]byte{
+			common.HexToHash(accKey): randomAccount(),
+		}
+	}
+	makeRoot := func(height uint64) common.Hash {
+		var buffer [8]byte
+		binary.BigEndian.PutUint64(buffer[:], height)
+		return common.BytesToHash(buffer[:])
+	}
+	var (
+		last = common.HexToHash("0x01")
+		head common.Hash
+	)
+	// Create a starting base layer and a snapshot tree out of it
+	base := &diskLayer{
+		diskdb: rawdb.NewMemoryDatabase(),
+		root:   common.HexToHash("0x01"),
+		cache:  fastcache.New(1024 * 500),
+	}
+	snaps := &Tree{
+		layers: map[common.Hash]snapshot{
+			base.root: base,
+		},
+		baseTime: time.Now(),
+		config: Config{
+			EnableSnapRootInterval: true,
+			SnapRootThreshold:      300,
+		},
+	}
+
+	// adding layers to the tree more than 128
+	for i := 0; i < 150; i++ {
+		head = makeRoot(uint64(i + 2))
+		snaps.Update(head, last, nil, setAccount(fmt.Sprintf("%d", i+2)), nil)
+		last = head
+	}
+
+	// Currently the tree should have all the 150 layers + disk layer
+	if count := len(snaps.layers); count != 151 {
+		t.Errorf("Unexpected number of layers - count %d, expected 151", count)
+	}
+
+	// Now capping without time threshold reached
+	if err := snaps.Cap(head, 128); err != nil {
+		t.Error("Error while capping layers", err)
+	}
+
+	// the diskRoot should not have been updated yet since
+	// the time and the memory limit have not been reached
+	if firstDiskRoot := snaps.diskRoot(); firstDiskRoot != base.root {
+		t.Errorf("Disk root should not have updated at this point - actual: %s, expected: %s", firstDiskRoot, base.root)
+	}
+
+	// layers beyond 128 should be flattened into one so total layers
+	// 128 top layers + 1 flattened layer + disk layer
+	if newLayers := len(snaps.layers); newLayers != 130 {
+		t.Errorf("Unexpected number of layers after flatten - count: %d, expected: 130", newLayers)
+	}
+
+	// Setting baseTime 10 min behind to trigger forceSnapshot
+	snaps.baseTime = time.Now().Add(time.Duration(-10) * time.Minute)
+
+	// Check if forceSnapshot disabled, time threshold should not trigger snapshot
+	snaps.config.EnableSnapRootInterval = false
+	if err := snaps.Cap(head, 128); err != nil {
+		t.Error("Error while capping layers", err)
+	}
+
+	// the diskRoot should not have been updated yet since
+	// the force snapshot is disabled
+	if firstDiskRoot := snaps.diskRoot(); firstDiskRoot != base.root {
+		t.Errorf("Disk root should not have updated at this point - actual: %s, expected: %s", firstDiskRoot, base.root)
+	}
+
+	// Re-enable forceSnapshot, time threshold should trigger snapshot
+	snaps.config.EnableSnapRootInterval = true
+	if err := snaps.Cap(head, 128); err != nil {
+		t.Error("Error while capping layers", err)
+	}
+
+	// the diskRoot should have been updated now since the time and the memory limit
+	// have not been reached
+	if updatedDiskRoot := snaps.diskRoot(); updatedDiskRoot == base.root {
+		t.Errorf("Disk root did not update at this point - actual: %s", updatedDiskRoot)
+	}
+
+	// disk layer should be updated now to be the flattened layer
+	// 128 top layers + disk layer
+	if newLayers := len(snaps.layers); newLayers != 129 {
+		t.Errorf("Unexpected number of layers after flatten - count: %d, expected: 130", newLayers)
+	}
+}
+
 // TestSnaphots tests the functionality for retrieving the snapshot
 // with given head root and the desired depth.
 func TestSnaphots(t *testing.T) {

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -355,23 +355,9 @@ func TestForceSnapRootCaps(t *testing.T) {
 			base.root: base,
 		},
 		config: Config{
+			AllowForceUpdate:        true,
 			SnapRootCommitThreshold: 10,
 		},
-	}
-
-	// validate compareThreshold method when disabled
-	if compare := snaps.CompareThreshold(100); compare {
-		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: false", compare)
-	}
-
-	// validate compareThreshold method when enabled
-	snaps.config.AllowForceUpdate = true
-	if compare := snaps.CompareThreshold(5); compare {
-		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: false", compare)
-	}
-
-	if compare := snaps.CompareThreshold(20); !compare {
-		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: true", compare)
 	}
 
 	// adding layers to the tree more than 128
@@ -430,6 +416,24 @@ func TestForceSnapRootCaps(t *testing.T) {
 	if newLayers := len(snaps.layers); newLayers != 129 {
 		t.Errorf("Unexpected number of layers after flatten - count: %d, expected: 130", newLayers)
 	}
+
+	// validate compareThreshold method when enabled
+	snaps.commitCounter = 5
+	if compare := snaps.CompareThreshold(); compare {
+		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: false", compare)
+	}
+
+	snaps.commitCounter = 200
+	if compare := snaps.CompareThreshold(); !compare {
+		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: true", compare)
+	}
+
+	// validate compareThreshold method when disabled
+	snaps.config.AllowForceUpdate = false
+	if compare := snaps.CompareThreshold(); compare {
+		t.Errorf("Incorrect CompareThreshold return - actual: %t, expected: false", compare)
+	}
+
 }
 
 // TestSnaphots tests the functionality for retrieving the snapshot

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1045,7 +1045,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	// If snapshotting is enabled, update the snapshot tree with this new version
 	if s.snap != nil {
 		start := time.Now()
-		log.Debug("Snapshot update status", "parent", s.snap.Root(), "root", root)
+		log.Debug("Snapshot update status", "parent", s.snap.Root(), "root", root, "diskroot", s.snaps.DiskRoot())
 		// Only update if there's a state transition (skip empty Clique blocks)
 		if parent := s.snap.Root(); parent != root {
 			if err := s.snaps.Update(root, parent, s.convertAccountSet(s.stateObjectsDestruct), s.snapAccounts, s.snapStorage); err != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -109,9 +109,6 @@ type StateDB struct {
 	validRevisions []revision
 	nextRevisionId int
 
-	// Commit counters
-	SnapshotCommitCounter int
-
 	// Measurements gathered during execution for debugging purposes
 	AccountReads         time.Duration
 	AccountHashes        time.Duration
@@ -1051,10 +1048,6 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		log.Debug("Snapshot update status", "parent", s.snap.Root(), "root", root, "skipping", (s.snap.Root() == root))
 		if parent := s.snap.Root(); parent != root {
 
-			force := s.compareCommits()
-
-			log.Debug("Commit counter", "counter", s.SnapshotCommitCounter, "force", force)
-
 			if err := s.snaps.Update(root, parent, s.convertAccountSet(s.stateObjectsDestruct), s.snapAccounts, s.snapStorage); err != nil {
 				log.Warn("Failed to update snapshot tree", "from", parent, "to", root, "err", err)
 			}
@@ -1062,7 +1055,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 			// - head layer is paired with HEAD state
 			// - head-1 layer is paired with HEAD-1 state
 			// - head-127 layer(bottom-most diff layer) is paired with HEAD-127 state
-			if err := s.snaps.Cap(root, 128, force); err != nil {
+			if err := s.snaps.Cap(root, 128, s.snaps.CompareThreshold()); err != nil {
 				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 128, "err", err)
 			}
 		}
@@ -1182,16 +1175,4 @@ func (s *StateDB) convertAccountSet(set map[common.Address]struct{}) map[common.
 		}
 	}
 	return ret
-}
-
-func (s *StateDB) compareCommits() bool {
-	if s.snaps.CompareThreshold(s.SnapshotCommitCounter) {
-		// reset the counter
-		s.SnapshotCommitCounter = 0
-		log.Debug("ReSetting counter")
-		return true
-	}
-	log.Debug("Updating Counter", "counter", s.SnapshotCommitCounter)
-	s.SnapshotCommitCounter++
-	return false
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -958,6 +958,7 @@ func (s *StateDB) clearJournalAndRefund() {
 
 // Commit writes the state to the underlying in-memory trie database.
 func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
+	log.Debug("Committing StateDB")
 	// Short circuit in case any database failure occurred earlier.
 	if s.dbErr != nil {
 		return common.Hash{}, fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
@@ -1003,6 +1004,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		// and in path-based-scheme some technical challenges are still unsolved.
 		// Although it won't affect the correctness but please fix it TODO(rjl493456442).
 	}
+	log.Debug("State Object Dirty complete")
 	if len(s.stateObjectsDirty) > 0 {
 		s.stateObjectsDirty = make(map[common.Address]struct{})
 	}
@@ -1017,6 +1019,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		start = time.Now()
 	}
 	root, set := s.trie.Commit(true)
+	log.Debug("Trie commit root", "root", root)
 	// Merge the dirty nodes of account trie into global set
 	if set != nil {
 		if err := nodes.Merge(set); err != nil {
@@ -1038,9 +1041,11 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		s.AccountUpdated, s.AccountDeleted = 0, 0
 		s.StorageUpdated, s.StorageDeleted = 0, 0
 	}
+	log.Debug("Checking Snapshot enabled", "valid", (s.snap != nil))
 	// If snapshotting is enabled, update the snapshot tree with this new version
 	if s.snap != nil {
 		start := time.Now()
+		log.Debug("Snapshot update status", "parent", s.snap.Root(), "root", root)
 		// Only update if there's a state transition (skip empty Clique blocks)
 		if parent := s.snap.Root(); parent != root {
 			if err := s.snaps.Update(root, parent, s.convertAccountSet(s.stateObjectsDestruct), s.snapAccounts, s.snapStorage); err != nil {
@@ -1053,6 +1058,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 			if err := s.snaps.Cap(root, 128); err != nil {
 				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 128, "err", err)
 			}
+			log.Debug("Completed Snap cap")
 		}
 		if metrics.EnabledExpensive {
 			s.SnapshotCommits += time.Since(start)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -109,6 +109,9 @@ type StateDB struct {
 	validRevisions []revision
 	nextRevisionId int
 
+	// Commit counters
+	SnapshotCommitCounter int
+
 	// Measurements gathered during execution for debugging purposes
 	AccountReads         time.Duration
 	AccountHashes        time.Duration
@@ -1047,6 +1050,11 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		// Only update if there's a state transition (skip empty Clique blocks)
 		log.Debug("Snapshot update status", "parent", s.snap.Root(), "root", root, "skipping", (s.snap.Root() == root))
 		if parent := s.snap.Root(); parent != root {
+
+			force := s.compareCommits()
+
+			log.Debug("Commit counter", "counter", s.SnapshotCommitCounter, "force", force)
+
 			if err := s.snaps.Update(root, parent, s.convertAccountSet(s.stateObjectsDestruct), s.snapAccounts, s.snapStorage); err != nil {
 				log.Warn("Failed to update snapshot tree", "from", parent, "to", root, "err", err)
 			}
@@ -1054,7 +1062,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 			// - head layer is paired with HEAD state
 			// - head-1 layer is paired with HEAD-1 state
 			// - head-127 layer(bottom-most diff layer) is paired with HEAD-127 state
-			if err := s.snaps.Cap(root, 128); err != nil {
+			if err := s.snaps.Cap(root, 128, force); err != nil {
 				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 128, "err", err)
 			}
 		}
@@ -1174,4 +1182,16 @@ func (s *StateDB) convertAccountSet(set map[common.Address]struct{}) map[common.
 		}
 	}
 	return ret
+}
+
+func (s *StateDB) compareCommits() bool {
+	if s.snaps.CompareThreshold(s.SnapshotCommitCounter) {
+		// reset the counter
+		s.SnapshotCommitCounter = 0
+		log.Debug("ReSetting counter")
+		return true
+	}
+	log.Debug("Updating Counter", "counter", s.SnapshotCommitCounter)
+	s.SnapshotCommitCounter++
+	return false
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -958,7 +958,6 @@ func (s *StateDB) clearJournalAndRefund() {
 
 // Commit writes the state to the underlying in-memory trie database.
 func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
-	log.Debug("Committing StateDB")
 	// Short circuit in case any database failure occurred earlier.
 	if s.dbErr != nil {
 		return common.Hash{}, fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
@@ -1004,7 +1003,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		// and in path-based-scheme some technical challenges are still unsolved.
 		// Although it won't affect the correctness but please fix it TODO(rjl493456442).
 	}
-	log.Debug("State Object Dirty complete")
+
 	if len(s.stateObjectsDirty) > 0 {
 		s.stateObjectsDirty = make(map[common.Address]struct{})
 	}
@@ -1019,7 +1018,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		start = time.Now()
 	}
 	root, set := s.trie.Commit(true)
-	log.Debug("Trie commit root", "root", root)
+	log.Debug("Committed Trie root", "root", root)
 	// Merge the dirty nodes of account trie into global set
 	if set != nil {
 		if err := nodes.Merge(set); err != nil {
@@ -1041,12 +1040,12 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		s.AccountUpdated, s.AccountDeleted = 0, 0
 		s.StorageUpdated, s.StorageDeleted = 0, 0
 	}
-	log.Debug("Checking Snapshot enabled", "valid", (s.snap != nil))
+
 	// If snapshotting is enabled, update the snapshot tree with this new version
 	if s.snap != nil {
 		start := time.Now()
-		log.Debug("Snapshot update status", "parent", s.snap.Root(), "root", root, "diskroot", s.snaps.DiskRoot())
 		// Only update if there's a state transition (skip empty Clique blocks)
+		log.Debug("Snapshot update status", "parent", s.snap.Root(), "root", root, "skipping", (s.snap.Root() == root))
 		if parent := s.snap.Root(); parent != root {
 			if err := s.snaps.Update(root, parent, s.convertAccountSet(s.stateObjectsDestruct), s.snapAccounts, s.snapStorage); err != nil {
 				log.Warn("Failed to update snapshot tree", "from", parent, "to", root, "err", err)
@@ -1058,7 +1057,6 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 			if err := s.snaps.Cap(root, 128); err != nil {
 				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 128, "err", err)
 			}
-			log.Debug("Completed Snap cap")
 		}
 		if metrics.EnabledExpensive {
 			s.SnapshotCommits += time.Since(start)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -182,15 +182,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			EnablePreimageRecording: config.EnablePreimageRecording,
 		}
 		cacheConfig = &core.CacheConfig{
-			TrieCleanLimit:      config.TrieCleanCache,
-			TrieCleanJournal:    stack.ResolvePath(config.TrieCleanCacheJournal),
-			TrieCleanRejournal:  config.TrieCleanCacheRejournal,
-			TrieCleanNoPrefetch: config.NoPrefetch,
-			TrieDirtyLimit:      config.TrieDirtyCache,
-			TrieDirtyDisabled:   config.NoPruning,
-			TrieTimeLimit:       config.TrieTimeout,
-			SnapshotLimit:       config.SnapshotCache,
-			Preimages:           config.Preimages,
+			TrieCleanLimit:         config.TrieCleanCache,
+			TrieCleanJournal:       stack.ResolvePath(config.TrieCleanCacheJournal),
+			TrieCleanRejournal:     config.TrieCleanCacheRejournal,
+			TrieCleanNoPrefetch:    config.NoPrefetch,
+			TrieDirtyLimit:         config.TrieDirtyCache,
+			TrieDirtyDisabled:      config.NoPruning,
+			TrieTimeLimit:          config.TrieTimeout,
+			SnapshotLimit:          config.SnapshotCache,
+			Preimages:              config.Preimages,
+			EnableSnapRootInterval: config.EnableSnapRootInterval,
+			SnapRootThreshold:      config.SnapRootThreshold,
 		}
 	)
 	// Override the chain config with provided settings.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -182,17 +182,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			EnablePreimageRecording: config.EnablePreimageRecording,
 		}
 		cacheConfig = &core.CacheConfig{
-			TrieCleanLimit:         config.TrieCleanCache,
-			TrieCleanJournal:       stack.ResolvePath(config.TrieCleanCacheJournal),
-			TrieCleanRejournal:     config.TrieCleanCacheRejournal,
-			TrieCleanNoPrefetch:    config.NoPrefetch,
-			TrieDirtyLimit:         config.TrieDirtyCache,
-			TrieDirtyDisabled:      config.NoPruning,
-			TrieTimeLimit:          config.TrieTimeout,
-			SnapshotLimit:          config.SnapshotCache,
-			Preimages:              config.Preimages,
-			EnableSnapRootInterval: config.EnableSnapRootInterval,
-			SnapRootThreshold:      config.SnapRootThreshold,
+			TrieCleanLimit:          config.TrieCleanCache,
+			TrieCleanJournal:        stack.ResolvePath(config.TrieCleanCacheJournal),
+			TrieCleanRejournal:      config.TrieCleanCacheRejournal,
+			TrieCleanNoPrefetch:     config.NoPrefetch,
+			TrieDirtyLimit:          config.TrieDirtyCache,
+			TrieDirtyDisabled:       config.NoPruning,
+			TrieTimeLimit:           config.TrieTimeout,
+			SnapshotLimit:           config.SnapshotCache,
+			Preimages:               config.Preimages,
+			AllowForceUpdate:        config.AllowForceUpdate,
+			SnapRootCommitThreshold: config.SnapRootCommitThreshold,
 		}
 	)
 	// Override the chain config with provided settings.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -182,17 +182,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			EnablePreimageRecording: config.EnablePreimageRecording,
 		}
 		cacheConfig = &core.CacheConfig{
-			TrieCleanLimit:          config.TrieCleanCache,
-			TrieCleanJournal:        stack.ResolvePath(config.TrieCleanCacheJournal),
-			TrieCleanRejournal:      config.TrieCleanCacheRejournal,
-			TrieCleanNoPrefetch:     config.NoPrefetch,
-			TrieDirtyLimit:          config.TrieDirtyCache,
-			TrieDirtyDisabled:       config.NoPruning,
-			TrieTimeLimit:           config.TrieTimeout,
-			SnapshotLimit:           config.SnapshotCache,
-			Preimages:               config.Preimages,
-			AllowForceUpdate:        config.AllowForceUpdate,
-			SnapRootCommitThreshold: config.SnapRootCommitThreshold,
+			TrieCleanLimit:      config.TrieCleanCache,
+			TrieCleanJournal:    stack.ResolvePath(config.TrieCleanCacheJournal),
+			TrieCleanRejournal:  config.TrieCleanCacheRejournal,
+			TrieCleanNoPrefetch: config.NoPrefetch,
+			TrieDirtyLimit:      config.TrieDirtyCache,
+			TrieDirtyDisabled:   config.NoPruning,
+			TrieTimeLimit:       config.TrieTimeout,
+			SnapshotLimit:       config.SnapshotCache,
+			Preimages:           config.Preimages,
+			AllowForceUpdate:    config.AllowForceUpdate,
+			CommitThreshold:     config.CommitThreshold,
 		}
 	)
 	// Override the chain config with provided settings.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -167,6 +167,8 @@ type Config struct {
 	TrieTimeout             time.Duration `toml:",omitempty"` // Cumulative Time interval spent on gc, after which to flush trie cache to disk
 	SnapshotCache           int
 	Preimages               bool
+	EnableSnapRootInterval  bool
+	SnapRootThreshold       int
 
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -167,8 +167,8 @@ type Config struct {
 	TrieTimeout             time.Duration `toml:",omitempty"` // Cumulative Time interval spent on gc, after which to flush trie cache to disk
 	SnapshotCache           int
 	Preimages               bool
-	EnableSnapRootInterval  bool
-	SnapRootThreshold       int
+	AllowForceUpdate        bool
+	SnapRootCommitThreshold int
 
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -168,7 +168,7 @@ type Config struct {
 	SnapshotCache           int
 	Preimages               bool
 	AllowForceUpdate        bool
-	SnapRootCommitThreshold int
+	CommitThreshold         int
 
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -48,8 +48,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TrieTimeout             time.Duration `toml:",omitempty"`
 		SnapshotCache           int
 		Preimages               bool
-		EnableSnapRootInterval  bool
-		SnapRootThreshold       int
+		AllowForceUpdate        bool
+		SnapRootCommitThreshold int
 		FilterLogCacheSize      int
 		Miner                   miner.Config
 		Ethash                  ethash.Config
@@ -95,8 +95,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TrieTimeout = c.TrieTimeout
 	enc.SnapshotCache = c.SnapshotCache
 	enc.Preimages = c.Preimages
-	enc.EnableSnapRootInterval = c.EnableSnapRootInterval
-	enc.SnapRootThreshold = c.SnapRootThreshold
+	enc.AllowForceUpdate = c.AllowForceUpdate
+	enc.SnapRootCommitThreshold = c.SnapRootCommitThreshold
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
 	enc.Miner = c.Miner
 	enc.Ethash = c.Ethash
@@ -146,8 +146,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TrieTimeout             *time.Duration `toml:",omitempty"`
 		SnapshotCache           *int
 		Preimages               *bool
-		EnableSnapRootInterval  *bool
-		SnapRootThreshold       *int
+		AllowForceUpdate        *bool
+		SnapRootCommitThreshold *int
 		FilterLogCacheSize      *int
 		Miner                   *miner.Config
 		Ethash                  *ethash.Config
@@ -256,11 +256,11 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.Preimages != nil {
 		c.Preimages = *dec.Preimages
 	}
-	if dec.EnableSnapRootInterval != nil {
-		c.EnableSnapRootInterval = *dec.EnableSnapRootInterval
+	if dec.AllowForceUpdate != nil {
+		c.AllowForceUpdate = *dec.AllowForceUpdate
 	}
-	if dec.SnapRootThreshold != nil {
-		c.SnapRootThreshold = *dec.SnapRootThreshold
+	if dec.SnapRootCommitThreshold != nil {
+		c.SnapRootCommitThreshold = *dec.SnapRootCommitThreshold
 	}
 	if dec.FilterLogCacheSize != nil {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -45,9 +45,11 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TrieCleanCacheJournal   string        `toml:",omitempty"`
 		TrieCleanCacheRejournal time.Duration `toml:",omitempty"`
 		TrieDirtyCache          int
-		TrieTimeout             time.Duration
+		TrieTimeout             time.Duration `toml:",omitempty"`
 		SnapshotCache           int
 		Preimages               bool
+		EnableSnapRootInterval  bool
+		SnapRootThreshold       int
 		FilterLogCacheSize      int
 		Miner                   miner.Config
 		Ethash                  ethash.Config
@@ -93,6 +95,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TrieTimeout = c.TrieTimeout
 	enc.SnapshotCache = c.SnapshotCache
 	enc.Preimages = c.Preimages
+	enc.EnableSnapRootInterval = c.EnableSnapRootInterval
+	enc.SnapRootThreshold = c.SnapRootThreshold
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
 	enc.Miner = c.Miner
 	enc.Ethash = c.Ethash
@@ -139,9 +143,11 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TrieCleanCacheJournal   *string        `toml:",omitempty"`
 		TrieCleanCacheRejournal *time.Duration `toml:",omitempty"`
 		TrieDirtyCache          *int
-		TrieTimeout             *time.Duration
+		TrieTimeout             *time.Duration `toml:",omitempty"`
 		SnapshotCache           *int
 		Preimages               *bool
+		EnableSnapRootInterval  *bool
+		SnapRootThreshold       *int
 		FilterLogCacheSize      *int
 		Miner                   *miner.Config
 		Ethash                  *ethash.Config
@@ -249,6 +255,12 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.Preimages != nil {
 		c.Preimages = *dec.Preimages
+	}
+	if dec.EnableSnapRootInterval != nil {
+		c.EnableSnapRootInterval = *dec.EnableSnapRootInterval
+	}
+	if dec.SnapRootThreshold != nil {
+		c.SnapRootThreshold = *dec.SnapRootThreshold
 	}
 	if dec.FilterLogCacheSize != nil {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -49,7 +49,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		SnapshotCache           int
 		Preimages               bool
 		AllowForceUpdate        bool
-		SnapRootCommitThreshold int
+		CommitThreshold         int
 		FilterLogCacheSize      int
 		Miner                   miner.Config
 		Ethash                  ethash.Config
@@ -96,7 +96,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.SnapshotCache = c.SnapshotCache
 	enc.Preimages = c.Preimages
 	enc.AllowForceUpdate = c.AllowForceUpdate
-	enc.SnapRootCommitThreshold = c.SnapRootCommitThreshold
+	enc.CommitThreshold = c.CommitThreshold
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
 	enc.Miner = c.Miner
 	enc.Ethash = c.Ethash
@@ -147,7 +147,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		SnapshotCache           *int
 		Preimages               *bool
 		AllowForceUpdate        *bool
-		SnapRootCommitThreshold *int
+		CommitThreshold         *int
 		FilterLogCacheSize      *int
 		Miner                   *miner.Config
 		Ethash                  *ethash.Config
@@ -259,8 +259,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.AllowForceUpdate != nil {
 		c.AllowForceUpdate = *dec.AllowForceUpdate
 	}
-	if dec.SnapRootCommitThreshold != nil {
-		c.SnapRootCommitThreshold = *dec.SnapRootCommitThreshold
+	if dec.CommitThreshold != nil {
+		c.CommitThreshold = *dec.CommitThreshold
 	}
 	if dec.FilterLogCacheSize != nil {
 		c.FilterLogCacheSize = *dec.FilterLogCacheSize


### PR DESCRIPTION
This PR adds the ability to force a diskRoot update after a time threshold. This can be enabled by the following in the config file
`AllowForceUpdate` - To enable/disable Force update of the state
`CommitThreshold` - Number of state changes before force update

## Current Scenario
The snapshot layers maintains a layer of 128 different block roots. Blocks with no transactions have the same root thus do not get updated to the layers. Snapshots beyond that point are flattened into one. Flattened layer is only merged with the snapshot on the disk once the memory of the flattened layers reaches the limit of ~4MB. This could take a lot of time. When a node falls over or has a unclean shutdown and enters a missing head state during start up, it rewinds back to this diskRoot, which could mean a significant roll back based on the activity/size of transactions.  

## Proposed Scenario
This PR adds a forcing function that is triggered based on commit threshold. After the first 128 layers of snapshot, the flattened layers are merged with the diskRoot when either the memory limit is reached or the commit threshold has been crossed. This allows more frequent update of the diskRoot thus potentially preventing large roll backs

Related eth-boot PR - https://github.com/kaleido-io/photic-eth-boot/pull/112